### PR TITLE
Fix code example in README. Bump psr7 version to allow 2.X.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $config = Configuration::getDefaultConfiguration()
     ->setPassword('<MESSENTE_API_PASSWORD>');
 
 $apiInstance = new OmnimessageApi(
-    new GuzzleHttp\Client(),
+    new \GuzzleHttp\Client(),
     $config
 );
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.2 || ^7.0",
-        "guzzlehttp/psr7": "^1.8"
+        "guzzlehttp/psr7": "^1.8 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4",


### PR DESCRIPTION
Hey,

I was able to run with the latest guzzlehttp/guzzle and guzzlehttp/psr7. Feel free to add "^2.0" for "guzzlehttp/psr7".
Also I found, that in code example "new GuzzleHttp\Client()" starting slash missed causing an exception while running, proposed an update.